### PR TITLE
AWSテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,12 @@
     max-width: 576px;
     padding: 2rem;
   }
+
+  .table-container {
+    margin: 0 auto;
+    width: 710px;
+  }
+
+.aws-table-head {
+    background-color: #007bff;
+  }

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -1,0 +1,4 @@
+class AwsTextsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -1,4 +1,5 @@
 class AwsTextsController < ApplicationController
   def index
+    @aws_texts = AwsText.all
   end
 end

--- a/app/models/aws_text.rb
+++ b/app/models/aws_text.rb
@@ -1,4 +1,21 @@
 class AwsText < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true
+
+  def self.import(path)
+    list = []
+    CSV.foreach(path, headers: true) do |row|
+      list << {
+        title: row["title"],
+        content: row["content"]
+      }
+    end
+    puts "インポート処理を開始"
+    AwsText.create!(list)
+    puts "インポート完了!!"
+  rescue ActiveModel::UnknownAttributeError => invalid
+    puts "インポートに失敗：UnknownAttributeError"
+  end
+
 end
+

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -2,7 +2,7 @@
   <h2>AWS教材の一覧ページ</h2>
 </div>
 
-<div class="table-container">
+  <div class="table-container">
   <table class="table table-striped">
     <thead class="aws-table-head text-white">
         <tr>
@@ -11,73 +11,14 @@
         </tr>
     </thead>
     <tbody>
+      <% @aws_texts.each do |aws_text| %>
         <tr>
-            <td>1</td>
+            <td><%= "#{aws_text.id}" %></td>
             <td>
-              <a href= "#">【 第1章 】ネットワーク環境設定</a>
+              <a href= "#"><%= "#{aws_text.title}" %></a>
             </td>
         </tr>
-        <tr>
-            <td>2</td>
-            <td>
-              <a href = "#">【 第2章 】RDSの設定</a>
-            </td>
-        </tr>
-        <tr>
-            <td>3</td>
-            <td>
-              <a href = "#">【 第3章 】EC2の設定</a>
-            </td>
-        </tr>
-        <tr>
-            <td>4</td>
-            <td>
-              <a href = "#">【 第4章 】サーバー環境の構築</a>
-            </td>
-        </tr>
-        <tr>
-            <td>5</td>
-            <td>
-              <a href = "#">【 第5章 】Railsアプリを配置する</a>
-            </td>
-        </tr>
-        <tr>
-            <td>6</td>
-            <td>
-              <a href = "#">【 第6章 】ロードバランサーを設定する</a>
-            </td>
-        </tr>
-        <tr>
-            <td>7</td>
-            <td>
-              <a href = "#">【 第7章 】Railsアプリの起動</a>
-            </td>
-        </tr>
-        <tr>
-            <td>8</td>
-            <td>
-              <a href = "#">【 第8章 】ドメインの取得</a>
-            </td>
-        </tr>
-        <tr>
-            <td>9</td>
-            <td>
-              <a href = "#">【 第9章 】IPアドレスとドメインの関連付け設定</a>
-            </td>
-        </tr>
-        <tr>
-            <td>10</td>
-            <td>
-              <a href = "#">【 第10章 】ACMでSSL証明書の取得</a>
-            </td>
-        </tr>
-        <tr>
-            <td>11</td>
-            <td>
-              <a href = "#">【 第11章 】https化に向けた設定</a>
-            </td>
-        </tr>
-
+      <% end %>
     </tbody>
   </table>
-</div>
+  </div>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -1,0 +1,83 @@
+<div class = "text-center">
+  <h2>AWS教材の一覧ページ</h2>
+</div>
+
+<div class="table-container">
+  <table class="table table-striped">
+    <thead class="aws-table-head text-white">
+        <tr>
+            <th>No.</th>
+            <th>内容</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>
+              <a href= "#">【 第1章 】ネットワーク環境設定</a>
+            </td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td>
+              <a href = "#">【 第2章 】RDSの設定</a>
+            </td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>
+              <a href = "#">【 第3章 】EC2の設定</a>
+            </td>
+        </tr>
+        <tr>
+            <td>4</td>
+            <td>
+              <a href = "#">【 第4章 】サーバー環境の構築</a>
+            </td>
+        </tr>
+        <tr>
+            <td>5</td>
+            <td>
+              <a href = "#">【 第5章 】Railsアプリを配置する</a>
+            </td>
+        </tr>
+        <tr>
+            <td>6</td>
+            <td>
+              <a href = "#">【 第6章 】ロードバランサーを設定する</a>
+            </td>
+        </tr>
+        <tr>
+            <td>7</td>
+            <td>
+              <a href = "#">【 第7章 】Railsアプリの起動</a>
+            </td>
+        </tr>
+        <tr>
+            <td>8</td>
+            <td>
+              <a href = "#">【 第8章 】ドメインの取得</a>
+            </td>
+        </tr>
+        <tr>
+            <td>9</td>
+            <td>
+              <a href = "#">【 第9章 】IPアドレスとドメインの関連付け設定</a>
+            </td>
+        </tr>
+        <tr>
+            <td>10</td>
+            <td>
+              <a href = "#">【 第10章 】ACMでSSL証明書の取得</a>
+            </td>
+        </tr>
+        <tr>
+            <td>11</td>
+            <td>
+              <a href = "#">【 第11章 】https化に向けた設定</a>
+            </td>
+        </tr>
+
+    </tbody>
+  </table>
+</div>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -11,9 +11,9 @@
         </tr>
     </thead>
     <tbody>
-      <% @aws_texts.each do |aws_text| %>
+      <% @aws_texts.each.with_index(1) do |aws_text,i| %>
         <tr>
-            <td><%= "#{aws_text.id}" %></td>
+            <td><%= "#{i}" %></td>
             <td>
               <a href= "#"><%= "#{aws_text.title}" %></a>
             </td>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -16,7 +16,7 @@
     </div>
     </li>
       <li class="nav-item active">
-        <a class="nav-link" href="#">AWSテキスト教材</a>
+        <a class="nav-link" href="/aws_texts">AWSテキスト教材</a>
       </li>
       <li class="nav-item active">
         <a class="nav-link" href="#">質問集</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   root to: 'movies#index'
+  get 'aws_texts', to: 'aws_texts#index'
 end


### PR DESCRIPTION
AWS教材の一覧ページを作成
Bootstrapでスタイルも似せる
タスク8の rake タスクを使用すれば初期データを入れる
ナビバーのAWS教材ページへのリンクが機能するようにする