### PR TITLE
AWSテキスト教材詳細ページの実装を行いました

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ gem 'activeadmin'
 gem 'devise'
 gem 'devise-i18n'
 gem 'rails-i18n'
-
+gem 'redcarpet'
+gem 'coderay'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.0)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -259,6 +260,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -271,6 +273,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.2)
   rails-i18n
+  redcarpet
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,9 @@
 .aws-table-head {
     background-color: #007bff;
   }
+
+.aws_text_content {
+    margin: 0 auto;
+    width: 90%;
+    padding: 50px 0 160px 0;
+  }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,7 +6,7 @@
     padding: 2rem;
   }
 
-  .table-container {
+.table-container {
     margin: 0 auto;
     width: 710px;
   }
@@ -15,8 +15,14 @@
     background-color: #007bff;
   }
 
-.aws_text_content {
+.aws-text-content {
+    width: 710px;
     margin: 0 auto;
-    width: 90%;
+    text-align: left;
     padding: 50px 0 160px 0;
+  }
+
+.content {
+   margin: 0 auto; 
+   text-align: center;
   }

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -2,4 +2,8 @@ class AwsTextsController < ApplicationController
   def index
     @aws_texts = AwsText.all
   end
+
+  def show
+    @aws_texts = AwsText.find(params[:id])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,48 @@
 module ApplicationHelper
+  require "redcarpet"
+  require "coderay"
+
+    class HTMLwithCoderay < Redcarpet::Render::HTML
+        def block_code(code, language)
+            language = language.split(':')[0] if language.present?
+
+            case language.to_s
+            when 'rb'
+                lang = :ruby
+            when 'yml'
+                lang = :yaml
+            when 'css'
+                lang = :css
+            when 'html'
+                lang = :html
+            when ''
+                lang = :md
+            else
+                lang = language
+            end
+
+            CodeRay.scan(code, lang).div
+        end
+    end
+
+    def markdown(text)
+        html_render = HTMLwithCoderay.new(
+          filter_html: true,
+          hard_wrap: true,
+          link_attributes: { rel: 'nofollow', target: "_blank" }
+        )
+        options = {
+            autolink: true,
+            space_after_headers: true,
+            no_intra_emphasis: true,
+            fenced_code_blocks: true,
+            tables: true,
+            hard_wrap: true,
+            xhtml: true,
+            lax_html_blocks: true,
+            strikethrough: true
+        }
+        markdown = Redcarpet::Markdown.new(html_render, options)
+        markdown.render(text)
+    end
 end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -15,7 +15,7 @@
         <tr>
             <td><%= "#{i}" %></td>
             <td>
-              <a href= "#"><%= "#{aws_text.title}" %></a>
+              <%= link_to "#{aws_text.title}", aws_text_path(aws_text.id) %>
             </td>
         </tr>
       <% end %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,4 @@
+<div class = aws_text_content>
+  <h2><%= @aws_texts.title %></h2>
+  <%= markdown(@aws_texts.content).html_safe %>
+</div>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,4 +1,6 @@
-<div class = aws_text_content>
-  <h2><%= @aws_texts.title %></h2>
-  <%= markdown(@aws_texts.content).html_safe %>
+<div class="aws-text-content">
+  <section id="content">
+    <h2><%= @aws_texts.title %></h2>
+    <%= markdown(@aws_texts.content).html_safe %>
+  </section>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   root to: 'movies#index'
-  get 'aws_texts', to: 'aws_texts#index'
+  resources :aws_texts
 end


### PR DESCRIPTION
一覧ページの「内容」から詳細ページに移動できるようにしました

詳細ページの作成
     Markdownに対応した表示ができるようにしました

※別途、変更箇所として：
ルーティングの方法をresourcesに変更致しました。