### PR TITLE
18_Rails動画教材ページネーションの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem 'devise'
 gem 'devise-i18n'
 gem 'rails-i18n'
 gem 'kaminari'
+gem 'redcarpet'
+gem 'coderay'
 
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'activeadmin'
 gem 'devise'
 gem 'devise-i18n'
 gem 'rails-i18n'
+gem 'kaminari'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,7 @@ DEPENDENCIES
   devise-bootstrap-views
   devise-i18n
   jbuilder (~> 2.7)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.0)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -259,6 +260,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -272,6 +274,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.2)
   rails-i18n
+  redcarpet
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -3,6 +3,5 @@ class MoviesController < ApplicationController
 
   def index
     @movies = Movie.page(params[:page]).per(PER)
-    @movie_level = Movie.movie_level(params[:page])
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,7 @@
 class MoviesController < ApplicationController
+  PER = 10
+
   def index
-    @movies = Movie.all
+    @movies = Movie.page(params[:page]).per(PER)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -3,5 +3,6 @@ class MoviesController < ApplicationController
 
   def index
     @movies = Movie.page(params[:page]).per(PER)
+    @movie_level = Movie.movie_level(params[:page])
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,7 +1,5 @@
 class Movie < ApplicationRecord
     validates :title, presence: true
     validates :url, presence: true
-    def self.movie_level(page)
-        (self.page(page).current_page - 1) * 10
-    end
+    
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,5 +1,7 @@
 class Movie < ApplicationRecord
     validates :title, presence: true
     validates :url, presence: true
-        
+    def self.movie_level(page)
+        (self.page(page).current_page - 1) * 10
+    end
 end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,7 +1,7 @@
 <% @movies.each.with_index(1) do |movie, i| %>
     <div class="mt-5">
     <div align="center">
-    <p><nobr><%="Lv.#{i}：#{movie.title}" %></nobr></p>
+    <p><nobr><%= "Lv.#{@movie_level + i}： #{movie.title}" %></nobr></p>
     <iframe width="560" height="315" src="<%=movie.url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
     </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -6,3 +6,4 @@
     </div>
     </div>
   <% end %>
+  <div class="pagination justify-content-center"><%= paginate(@movies) %></div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,7 +1,7 @@
-<% @movies.each.with_index(1) do |movie, i| %>
+<% @movies.each.with_index(@movies.offset_value + 1) do |movie, i| %>
     <div class="mt-5">
     <div align="center">
-    <p><nobr><%= "Lv.#{@movie_level + i}： #{movie.title}" %></nobr></p>
+    <p><nobr><%= "Lv.#{i}： #{movie.title}" %></nobr></p>
     <iframe width="560" height="315" src="<%=movie.url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
     </div>


### PR DESCRIPTION
<実装内容>
・動画教材ページの、ページネーション実装

<質問>
ページネーションを実装すると、動画タイトルのレベル数が２ページ目以降もLv.1から始まります。見本のように、２ページ目以降はLv.11から、３ページ目以降はLv.21から始まるようにするにはどうしたらいいのでしょうか？
each.with_indexを調べたり、ページネーション インデックスと検索してみましたが、思うような結果が得られませんでした。
ページネーションはeach.with_indexメソッドの外に書いたので影響が無いと思ったのですが...。
アドバイスをいただけると嬉しいです。

<参考資料>
https://cccabinet.jpn.org/bootstrap4/components/pagination
https://qiita.com/residenti/items/1ae1e5ceb59c0729c0b9