### PR TITLE
26_PHP講座ページの実装

### DIFF
--- a/app/controllers/php_lectures_controller.rb
+++ b/app/controllers/php_lectures_controller.rb
@@ -1,0 +1,6 @@
+class PhpLecturesController < ApplicationController
+
+  def index
+    @php_lectures = PhpLecture.all
+  end
+end

--- a/app/models/php_lecture.rb
+++ b/app/models/php_lecture.rb
@@ -1,0 +1,2 @@
+class PhpLecture < ApplicationRecord
+end

--- a/app/models/php_lecture.rb
+++ b/app/models/php_lecture.rb
@@ -1,2 +1,4 @@
 class PhpLecture < ApplicationRecord
+  validates :title, presence: true
+  validates :url, presence: true
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -21,6 +21,10 @@
         <a class="nav-link" href="/aws_texts">AWSテキスト教材</a>
       </li>
 
+      <li class="nav-item active">
+        <a class="nav-link" href="/php_lectures">PHP講座</a>
+      </li>
+
     <% if user_signed_in? %>
       <li class="nav-item active">
     <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-link' %>

--- a/app/views/php_lectures/index.html.erb
+++ b/app/views/php_lectures/index.html.erb
@@ -1,0 +1,8 @@
+<% @php_lectures.each.with_index(1) do |php_lecture, i| %>
+  <div class="mt-5">
+    <div align="center">
+      <p><nobr><%= "#{php_lecture.title}" %></nobr></p>
+        <iframe width="560" height="315" src="<%=php_lecture.url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
+  </div>
+<% end %>

--- a/app/views/php_lectures/index.html.erb
+++ b/app/views/php_lectures/index.html.erb
@@ -1,7 +1,7 @@
 <% @php_lectures.each.with_index(1) do |php_lecture, i| %>
   <div class="mt-5">
-    <div align="center">
-      <p><nobr><%= "#{php_lecture.title}" %></nobr></p>
+    <div class="text-center">
+      <p><%= "#{php_lecture.title}" %></p>
         <iframe width="560" height="315" src="<%=php_lecture.url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   root to: 'movies#index'
   resources :aws_texts, only: [:index, :show]
   resources :live_codings, only: [:index]
+  resources :php_lectures, only: [:index]
   resources :questions, only: [:index, :create, :show] do
     resource :solutions, only: :create
   end

--- a/db/csv_data/php_lecture_data.csv
+++ b/db/csv_data/php_lecture_data.csv
@@ -1,0 +1,5 @@
+title,url
+Lesson 1,https://www.youtube.com/embed/qKy7X5umlqc
+Lesson 2,https://www.youtube.com/embed/tvzdT5_mIv0
+Lesson 3,https://www.youtube.com/embed/ZEh2SIKqkL0
+Lesson 4,https://www.youtube.com/embed/u_oLIlZuLKE

--- a/db/migrate/20200601153915_create_php_lectures.rb
+++ b/db/migrate/20200601153915_create_php_lectures.rb
@@ -1,0 +1,9 @@
+class CreatePhpLectures < ActiveRecord::Migration[6.0]
+  def change
+    create_table :php_lectures do |t|
+      t.string :title
+      t.string :url
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_28_213333) do
+ActiveRecord::Schema.define(version: 2020_06_01_153915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,13 @@ ActiveRecord::Schema.define(version: 2020_05_28_213333) do
   end
 
   create_table "movies", force: :cascade do |t|
+    t.string "title"
+    t.string "url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "php_lectures", force: :cascade do |t|
     t.string "title"
     t.string "url"
     t.datetime "created_at", precision: 6, null: false

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -66,6 +66,19 @@ namespace :import_csv do
    end
   end
 
+  task php_lectures: :environment do
+
+    list = Import.csv_data(path: 'db/csv_data/php_lecture_data.csv')
+
+   puts "インポート処理を開始"
+   begin
+    PhpLecture.create!(list)
+     puts "インポート完了!!"
+   rescue ActiveModel::UnknownAttributeError => invalid
+     puts "インポートに失敗：UnknownAttributeError"
+   end
+  end
+
 end
 
 

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -65,6 +65,8 @@ namespace :import_csv do
      puts "インポートに失敗：UnknownAttributeError"
    end
   end
+  
+  desc "php_lecture.csvをphp_lectureにインポートするタスク"
 
   task php_lectures: :environment do
 


### PR DESCRIPTION
【作業内容】
・ルーティング設定
・PHP講座ページのコントローラー、モデル作成
・CSVファイルをインポート（PHP講座ページ分のみ）
・ページの実装
・ナビバーにPHP講座を追加

【参考資料】
・見本のみ: https://arcane-gorge-21903.herokuapp.com/movies?genre=Php