### PR TITLE
28_情報発信ページの実装

### DIFF
--- a/app/controllers/marketings_controller.rb
+++ b/app/controllers/marketings_controller.rb
@@ -1,0 +1,6 @@
+class MarketingsController < ApplicationController
+
+  def index
+    @marketings = Marketing.all
+  end
+end

--- a/app/models/marketing.rb
+++ b/app/models/marketing.rb
@@ -1,0 +1,2 @@
+class Marketing < ApplicationRecord
+end

--- a/app/models/marketing.rb
+++ b/app/models/marketing.rb
@@ -1,2 +1,4 @@
 class Marketing < ApplicationRecord
+  validates :title, presence: true
+  validates :url, presence: true
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -25,6 +25,10 @@
         <a class="nav-link" href="/php_lectures">PHP講座</a>
       </li>
 
+      <li class="nav-item active">
+        <a class="nav-link" href="/marketings">情報発信</a>
+      </li>
+
     <% if user_signed_in? %>
       <li class="nav-item active">
     <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-link' %>

--- a/app/views/marketings/index.html.erb
+++ b/app/views/marketings/index.html.erb
@@ -1,0 +1,8 @@
+<% @marketings.each.with_index(1) do |marketing, i| %>
+  <div class="mt-5">
+    <div class="text-center">
+      <p><%= "Lv.#{i}： #{marketing.title}" %></p>
+        <iframe width="560" height="315" src="<%=marketing.url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,11 +6,8 @@ Rails.application.routes.draw do
   resources :aws_texts, only: [:index, :show]
   resources :live_codings, only: [:index]
   resources :php_lectures, only: [:index]
-<<<<<<< HEAD
   resources :marketings, only: [:index]
-=======
   resources :talks, only: [:index]
->>>>>>> master
   resources :questions, only: [:index, :create, :show] do
     resource :solutions, only: :create
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :aws_texts, only: [:index, :show]
   resources :live_codings, only: [:index]
   resources :php_lectures, only: [:index]
+  resources :marketings, only: [:index]
   resources :questions, only: [:index, :create, :show] do
     resource :solutions, only: :create
   end

--- a/db/csv_data/marketing_data.csv
+++ b/db/csv_data/marketing_data.csv
@@ -1,0 +1,3 @@
+title,url
+情報発信とは,https://www.youtube.com/embed/Wkorz--0xMo
+集客を自動化しよう,https://www.youtube.com/embed/ClTzB1fmYyw

--- a/db/migrate/20200604010330_create_marketings.rb
+++ b/db/migrate/20200604010330_create_marketings.rb
@@ -1,0 +1,9 @@
+class CreateMarketings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :marketings do |t|
+      t.string :title
+      t.string :url
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
-ActiveRecord::Schema.define(version: 2020_06_04_010330) do
-=======
-ActiveRecord::Schema.define(version: 2020_06_03_050015) do
->>>>>>> master
+ActiveRecord::Schema.define(version: 2020_06_04_025540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,13 +44,6 @@ ActiveRecord::Schema.define(version: 2020_06_03_050015) do
   create_table "aws_texts", force: :cascade do |t|
     t.string "title"
     t.text "content"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "conversations", force: :cascade do |t|
-    t.string "title"
-    t.string "url"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -102,9 +91,7 @@ ActiveRecord::Schema.define(version: 2020_06_03_050015) do
     t.index ["question_id"], name: "index_solutions_on_question_id"
   end
 
-  create_table "talking_videos", force: :cascade do |t|
   create_table "talks", force: :cascade do |t|
-
     t.string "title"
     t.string "url"
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_01_153915) do
+ActiveRecord::Schema.define(version: 2020_06_04_010330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,13 @@ ActiveRecord::Schema.define(version: 2020_06_01_153915) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "marketings", force: :cascade do |t|
+    t.string "title"
+    t.string "url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "movies", force: :cascade do |t|
     t.string "title"
     t.string "url"
@@ -82,6 +89,13 @@ ActiveRecord::Schema.define(version: 2020_06_01_153915) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["question_id"], name: "index_solutions_on_question_id"
+  end
+
+  create_table "talking_videos", force: :cascade do |t|
+    t.string "title"
+    t.string "url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -109,7 +109,7 @@ namespace :import_csv do
       puts "インポートに失敗：UnknownAttributeError"
     end
   end
->>>>>>> master
+  
 end
 
 

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -81,6 +81,21 @@ namespace :import_csv do
    end
   end
 
+  desc "marketing.csvをmarketingにインポートするタスク"
+
+  task marketings: :environment do
+
+    list = Import.csv_data(path: 'db/csv_data/marketing_data.csv')
+
+   puts "インポート処理を開始"
+   begin
+    Marketing.create!(list)
+     puts "インポート完了!!"
+   rescue ActiveModel::UnknownAttributeError => invalid
+     puts "インポートに失敗：UnknownAttributeError"
+   end
+  end
+
 end
 
 


### PR DESCRIPTION
【作業内容】  

- ルーティング設定  
- 情報発信ページのコントローラー、モデル作成  
- CSVファイルをインポート（情報発信ページ分のみ）  
- ページの実装  
- ナビバーに情報発信を追加
- 誤って作成してしまったtalking_videosテーブルを削除
- コンフリクト解消


【参考資料】  
- 見本: https://arcane-gorge-21903.herokuapp.com/movies?genre=Marketing
- 誤って作成したテーブルを削除するにあたって参考した記事 https://qiita.com/miyah-kun/items/1215e54c86e80e4b5324