### PR TITLE
動画教材ページの見た目をカードスタイルに変更

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,14 @@ body {
   text-align: center;
  }
 
+.card-body {
+  height: 200px;
+}
+
+.movie-text {
+  font-size: 25px; 
+}
+
 .main-bg-color {
   background-color: #5D99FF;
 }

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
-  PER = 10
+  PER = 18
 
   def index
     @movies = Movie.page(params[:page]).per(PER)

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -8,7 +8,7 @@
               <iframe width="560" height="315" src="<%=movie.url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
           </div>
-          <div class="card-body">
+          <div class="card-body movie-text">
             <p><%= "Lv.#{i}： #{movie.title}" %></p>
           </div>
         </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,10 +1,21 @@
-<% @movies.each.with_index(@movies.offset_value + 1) do |movie, i| %>
-  <div class="mt-5">
-    <div class="text-center">
-      <p><%= "Lv.#{i}： #{movie.title}" %></p>
-        <iframe width="560" height="315" src="<%=movie.url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-    </div>
+<div class="container-fluid">
+  <div class="row">
+    <% @movies.each.with_index(@movies.offset_value + 1) do |movie, i| %>
+      <div class="col-12 col-md-6 col-lg-4">
+        <div class="card border-dark mb-3">
+          <div class="card-header p-0">
+            <div class="embed-responsive embed-responsive-16by9">
+              <iframe width="560" height="315" src="<%=movie.url%>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            </div>
+          </div>
+          <div class="card-body">
+            <p><%= "Lv.#{i}： #{movie.title}" %></p>
+          </div>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>
+
   
 <div class="pagination justify-content-center"><%= paginate(@movies) %></div>


### PR DESCRIPTION
【作業内容】

- 動画教材ページの見た目をカードスタイルに変更

【参考資料】

- 見本ページ
- カードスタイルにするために参考

https://getbootstrap.jp/docs/4.2/components/card/