### PR TITLE
グルーピングされる位置を修正しました

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,11 +1,11 @@
 <nav class="navbar navbar-expand-lg navbar-dark sticky-top <%= line_color %>">
   
-  <div class="collapse navbar-collapse justify-content-center" id="navbarSupportedContent">
-    <%= link_to "GyakutenCloneGroup", root_path, class:"navbar-brand" %>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
+  <%= link_to "GyakutenCloneGroup", root_path, class:"navbar-brand" %>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
 
+  <div class="collapse navbar-collapse justify-content-center" id="navbarSupportedContent">
     <ul class="nav navbar-nav">
       <li class="nav-item dropdown active">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
【バグの箇所】
画面横幅が992未満になるとナビバーが切り替わらずに消えてしまう。

【行ったこと】
画面幅が所定のサイズ以下になったときに折りたたまれグルーピングさせる記述の行を変更しました。

【参考】
https://knowledge.cpi.ad.jp/tech/navbar/
https://hirokiblog.net/bootstrap-navbar/